### PR TITLE
Add link to CurseForge mod page as "homepage" in fabric.mod.json

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -9,6 +9,7 @@
     "CerulanLumina"
   ],
   "contact": {
+    "homepage": "https://www.curseforge.com/minecraft/mc-mods/fairenchanting",
     "sources": "https://github.com/CerulanLumina/fair-enchanting"
   },
 


### PR DESCRIPTION
May make it easier for people stumbling over this repository to find the appropriate CurseForge page